### PR TITLE
0o Prefix for octal literals

### DIFF
--- a/extension/modules/log4moz.js
+++ b/extension/modules/log4moz.js
@@ -49,8 +49,8 @@ const MODE_CREATE   = 0x08;
 const MODE_APPEND   = 0x10;
 const MODE_TRUNCATE = 0x20;
 
-const PERMS_FILE      = 0644;
-const PERMS_DIRECTORY = 0755;
+const PERMS_FILE      = 0o644;
+const PERMS_DIRECTORY = 0o755;
 
 const ONE_BYTE = 1;
 const ONE_KILOBYTE = 1024 * ONE_BYTE;

--- a/extension/modules/service.js
+++ b/extension/modules/service.js
@@ -1437,7 +1437,7 @@ var FileUtils = {
             if (!dir.exists() || !dir.isDirectory()) {
                 if (!aDontCreate) {
                     // read and write permissions to owner and group, read-only for others.
-                    dir.create(Ci.nsIFile.DIRECTORY_TYPE, 0774);
+                    dir.create(Ci.nsIFile.DIRECTORY_TYPE, 0o774);
                 }
             }
         } catch (ex) {


### PR DESCRIPTION
Console Warnings Fix

SyntaxError: "0"-prefixed octal literals and octal escape sequences are
deprecated; for octal literals use the "0o" prefix instead log4moz.js:53:24