### PR TITLE
Remove Deprecated Expression Closure

### DIFF
--- a/extension/modules/Preferences.js
+++ b/extension/modules/Preferences.js
@@ -216,7 +216,7 @@ Preferences.prototype = {
 
   reset: function(prefName) {
     if (isArray(prefName)) {
-      prefName.map(function(v) this.reset(v), this);
+      prefName.map( v => this.reset(v), this);
       return;
     }
 


### PR DESCRIPTION
Remove Deprecated Expression Closure. This was not printed on console somehow, so could not notice for the previous PR.