### PR TITLE
Restrict Specific Dimensions and File Types  for header and footer when creating Cusom Personas

### DIFF
--- a/extension/content/customPersonaEditor.js
+++ b/extension/content/customPersonaEditor.js
@@ -213,12 +213,25 @@ var CustomPersonaEditor = {
     let property = control.id;
 
     let fp = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
+    fp.appendFilter("Images", "*.png; *.jpg; *.jpeg");
     fp.init(window,
             this._strings.get("backgroundPickerDialogTitle"),
             Ci.nsIFilePicker.modeOpen);
     let result = fp.show();
 
     if (result == Ci.nsIFilePicker.returnOK) {
+      var img = new Image();
+      img.src = fp.fileURL.spec;
+      img.onload = function() {
+          if (img.naturalWidth !== 3000 || img.naturalHeight !== 200) {
+              var prompt = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
+              if (prompt.confirm(null, "Personas Plus", "Image must be 3000 pixels wide and 200 pixels tall. This image does not meet required specifications.\n\nWould you like to read more about how to create your own background theme?")) {
+                  window.open("https://developer.mozilla.org/en-US/Add-ons/Themes/Background", '_blank');
+              }
+              return;
+          }
+      }
+
       // A random number is appended to avoid displaying a cached image
       // after the image has been modified.
       // See: https://bugzilla.mozilla.org/show_bug.cgi?id=543333


### PR DESCRIPTION
Restrict Specific Dimensions (3000 x 200) and File Types (png, jpg)
for header and footer when creating Custom Personas. 

A confirm prompt is provided for Mozilla page which tells how to create custom persona in details.

Fixes #54