### PR TITLE
Open links next to active tabs

### DIFF
--- a/extension/modules/personas.js
+++ b/extension/modules/personas.js
@@ -216,7 +216,7 @@ var PersonaController = {
                         }
                     }
                     if (!found)
-                        window.openUILinkIn(url, "tab");
+                        window.gBrowser.loadOneTab(url, {inBackground: false, relatedToCurrent:true});
                     break;
                 }
         }


### PR DESCRIPTION
Personas Plus opens links at the far end of the browser tabs for like
Persona > View Details. This commit makes sure the links open next to
active tab so that user can easily access it.