### PR TITLE
Chrome.manifest Support for SeaMonkey

### DIFF
--- a/extension/chrome.manifest
+++ b/extension/chrome.manifest
@@ -12,6 +12,14 @@ skin  personas  classic/1.0  skin/mac3.1/            application={ec8030f7-c20a-
 skin  personas  classic/1.0  skin/linux/             application={ec8030f7-c20a-464f-9b0e-13a3a9e97384}                      os=Linux
 skin  personas  classic/1.0  skin/linux/             application={ec8030f7-c20a-464f-9b0e-13a3a9e97384}                      os=SunOS
 skin  personas  classic/1.0  skin/linux/             application={ec8030f7-c20a-464f-9b0e-13a3a9e97384}                      os=FreeBSD
+skin  personas  classic/1.0  skin/winxp/             application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}                      os=WINNT   osversion<6
+skin  personas  classic/1.0  skin/winxp/             application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}                      os=WINCE
+skin  personas  classic/1.0  skin/vista/             application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}                      os=WINNT   osversion>=6
+skin  personas  classic/1.0  skin/mac3.0/            application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}  appversion<3.1b2    os=Darwin
+skin  personas  classic/1.0  skin/mac3.1/            application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}  appversion>=3.1b2   os=Darwin
+skin  personas  classic/1.0  skin/linux/             application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}                      os=Linux
+skin  personas  classic/1.0  skin/linux/             application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}                      os=SunOS
+skin  personas  classic/1.0  skin/linux/             application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}                      os=FreeBSD
 skin  personas  classic/1.0  skin/linux/thunderbird/ application={3550f703-e582-4d05-9a08-453d09bdfdc6}                      os=Linux
 skin  personas  classic/1.0  skin/linux/thunderbird/ application={3550f703-e582-4d05-9a08-453d09bdfdc6}                      os=SunOS
 skin  personas  classic/1.0  skin/linux/thunderbird/ application={3550f703-e582-4d05-9a08-453d09bdfdc6}                      os=FreeBSD


### PR DESCRIPTION
chrome.manifest declarations are missing for SeaMonkey. Because of that,

chrome://personas/skin/

does not get registered for SeaMonkey