### PR TITLE
Tab Support for SeaMonkey

### DIFF
--- a/extension/modules/personas.js
+++ b/extension/modules/personas.js
@@ -216,7 +216,7 @@ var PersonaController = {
                         }
                     }
                     if (!found)
-                        window.openUILinkIn(url, "tab");
+                        tabBrowser.loadOneTab(url, {inBackground: false});
                     break;
                 }
         }


### PR DESCRIPTION
Tab Support for SeaMonkey. SeaMonkey adds tab but makes it background which may lead user miss the opened tab. This PR makes sure SeaMonkey behaves like Firefox.

This does not alter Firefox behaviour. Firefox still opens tab at the
end of tab strip and as selected active tab.