### PR TITLE
Expose Some Methods by Component

### DIFF
--- a/extension/modules/personas.js
+++ b/extension/modules/personas.js
@@ -1236,6 +1236,9 @@ var PersonaController = {
     onQuitApplicationByShutDown: function() {
         PersonaService.onQuitApplication();
         Components.utils.unload("resource://personas/modules/service.js");
+    },
+    askRotation: function() {
+        PersonaService._rotatePersona();
     }
 
 };


### PR DESCRIPTION
For rotation add-ons, some methods need to be exposed.

Component named `PersonasPlusStartup` is registered/unregistered in
`bootstrap.js`.

`requestRotation` method is exposed. When it is called, it asks
`PersonaController` to switch them by `askRotation` method.

Because `PersonaService` is actually handles rotation, `askRotation` method
actually calls `PersonaService._rotatePersona` method.