### PR TITLE
onSelectBackground Fix

### DIFF
--- a/extension/content/customPersonaEditor.js
+++ b/extension/content/customPersonaEditor.js
@@ -234,9 +234,9 @@ var CustomPersonaEditor = {
               // A random number is appended to avoid displaying a cached image
               // after the image has been modified.
               // See: https://bugzilla.mozilla.org/show_bug.cgi?id=543333
-              control.value = this.customPersona[property] =
+              control.value = CustomPersonaEditor.customPersona[property] =
                   fp.fileURL.spec + "?" + Math.floor(Math.random() * 10000);
-              this._save();
+              CustomPersonaEditor._save();
           }
       }
     }


### PR DESCRIPTION
This commit fixes the bug while checking the image dimension. Because
code is moved, “this” applies to image rather than CustomPersonaEditor. Fixes #86