### PR TITLE
Rename README.txt to README.md and fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ Personas Plus
 
 Personas, also known as lightweight themes, is a way of creating Firefox themes,
 now deprecated. To learn about its replacement, check out the
-[https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Themes/Theme_concepts](documentation on themes)
+[documentation on themes](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Themes/Theme_concepts)
 on MDN.


### PR DESCRIPTION
Githubs automatic link to the documentation was broken due to the lack of spaces. However, since this looked like an attempt to use markdown, I changed the extension instead.
Thanks for all your work over the years.